### PR TITLE
Avoid matplotlib special case

### DIFF
--- a/conda-recipe/meta.yaml
+++ b/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pycpt
-  version: "2.2.1"
+  version: "2.2.2"
 
 source:
   path: ..

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ long_description = readme_path.read_text(encoding='utf-8')
 
 setup(
     name = "pycpt",
-    version = "2.2.1",
+    version = "2.2.2",
     author = "Kyle Hall",
     author_email = "pycpt-help@iri.columbia.edu",
     description = ("Python Interface to the International Research Institute for Climate & Society's Climate Predictability Tool "),

--- a/src/pycpt/__init__.py
+++ b/src/pycpt/__init__.py
@@ -1,6 +1,6 @@
 __author__ = "Kyle J. C. Hall (pycpt-help@iri.columbia.edu)"
 __license__ = "MIT"
-__version__ = "2.2.1"
+__version__ = "2.2.2"
 
 from .notebook import *
 from cptextras import save_configuration, load_configuration

--- a/src/pycpt/notebook.py
+++ b/src/pycpt/notebook.py
@@ -249,10 +249,8 @@ def plot_skill(predictor_names, skill, MOS, files_root, skill_metrics):
         ncols=len(skill_metrics),
         subplot_kw={"projection": cartopy.crs.PlateCarree()},
         figsize=(5 * len(skill_metrics), 2.5 * len(predictor_names)),
+        squeeze=False,
     )
-    if len(predictor_names) * len(skill_metrics) == 1:
-        ax = [ax]
-
     for i, model in enumerate(predictor_names):
         for j, skill_metric in enumerate(skill_metrics):
             metric = SKILL_METRICS[skill_metric]
@@ -774,19 +772,18 @@ def plot_mme_skill(
         ncols=len(skill_metrics),
         subplot_kw={"projection": ccrs.PlateCarree()},
         figsize=(5 * len(skill_metrics), 1 * len(predictor_names)),
+        squeeze=False,
     )
-    if len(skill_metrics) == 1:
-        ax = [ax]
 
-    for i in [1]:
+    for i in [0]:
         for j, skill_metric in enumerate(skill_metrics):
             metric = SKILL_METRICS[skill_metric]
-            ax[j].set_title(skill_metric)
+            ax[i][j].set_title(skill_metric)
             n = (
                 getattr(nextgen_skill, skill_metric)
                 .where(getattr(nextgen_skill, skill_metric) > missing_value_flag)
                 .plot(
-                    ax=ax[j],
+                    ax=ax[i][j],
                     cmap=metric[0],
                     vmin=metric[1],
                     vmax=metric[2],
@@ -794,9 +791,9 @@ def plot_mme_skill(
                 )
             )
 
-            ax[j].coastlines()
-            ax[j].add_feature(cartopy.feature.BORDERS)
-            ax[j].set_title(skill_metric.upper())
+            ax[i][j].coastlines()
+            ax[i][j].add_feature(cartopy.feature.BORDERS)
+            ax[i][j].set_title(skill_metric.upper())
 
             cb = plt.colorbar(n, orientation=graph_orientation)  # location='bottom')
             cb.set_label(label=skill_metric, size=15)


### PR DESCRIPTION
Fixes a display bug that occurs when using only one model. 

Using squeeze=False means that plt.subplot will always return a 2d array of axes, even if one of those dimensions has only a single row or column.