### PR TITLE
Don't make assumptions about the order of domain dict

### DIFF
--- a/src/pycpt/notebook.py
+++ b/src/pycpt/notebook.py
@@ -19,7 +19,10 @@ missing_value_flag = -999
 
 def setup(case_dir, domain):
     # extracting domain boundaries and create house keeping
-    e, w, n, s = domain.values()
+    e = domain['east']
+    w = domain['west']
+    n = domain['north']
+    s = domain['south']
 
     domainFolder = str(w) + "W-" + str(e) + "E" + "_to_" + str(s) + "S-" + str(n) + "N"
 


### PR DESCRIPTION
This code assumed that east, west, north, and south had been added to the domain dictionary in that order. When we save the dictionary to the config file and then read it back in, the order changes, and then we use the wrong name for the domain dir.