### PR TITLE
Changes to support automation of forecast generation

### DIFF
--- a/cpt-dl/src/cptdl/utilities.py
+++ b/cpt-dl/src/cptdl/utilities.py
@@ -76,6 +76,8 @@ class PyCPT_ERROR(Exception):
 
 def evaluate_url(url, ensemblemean=True, **kwargs):
     from .targetleadconv import seasonal_target, seasonal_target_length_monthly, seasonal_target_length, threeletters
+    # TODO The python docs say "The contents of [the locals] dictionary
+    # should not be modified."
     locals().update(**kwargs)
     return eval('f"{}"'.format(url))
 

--- a/pycpt/conda-recipe/meta.yaml
+++ b/pycpt/conda-recipe/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: pycpt
-  version: "2.5.0"
+  version: "2.5.2"
 
 source:
   path: ..

--- a/pycpt/setup.py
+++ b/pycpt/setup.py
@@ -6,7 +6,7 @@ long_description = readme_path.read_text(encoding='utf-8')
 
 setup(
     name = "pycpt",
-    version = "2.5.0",
+    version = "2.5.2",
     author = "Kyle Hall",
     author_email = "pycpt-help@iri.columbia.edu",
     description = ("Python Interface to the International Research Institute for Climate & Society's Climate Predictability Tool "),

--- a/pycpt/setup.py
+++ b/pycpt/setup.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 from setuptools import setup
 
-readme_path = Path(__file__).parent / 'README.md'
+readme_path = Path(__file__).parent.parent / 'README.md'
 long_description = readme_path.read_text(encoding='utf-8')
 
 setup(

--- a/pycpt/src/pycpt/__init__.py
+++ b/pycpt/src/pycpt/__init__.py
@@ -1,6 +1,6 @@
 __author__ = "Kyle J. C. Hall (pycpt-help@iri.columbia.edu)"
 __license__ = "MIT"
-__version__ = "2.5.0"
+__version__ = "2.5.2"
 
 from .notebook import *
 from cptextras import save_configuration, load_configuration

--- a/pycpt/src/pycpt/notebook.py
+++ b/pycpt/src/pycpt/notebook.py
@@ -28,6 +28,12 @@ def setup(case_dir, domain):
     domainFolder = str(w) + "W-" + str(e) + "E" + "_to_" + str(s) + "S-" + str(n) + "N"
 
     files_root = case_dir / domainFolder
+    setup_domain_dir(files_root)
+
+    return files_root
+
+
+def setup_domain_dir(files_root):
     files_root.mkdir(exist_ok=True, parents=True)
 
     dataDir = files_root / "data"
@@ -42,8 +48,6 @@ def setup(case_dir, domain):
     print(f"Input data will be saved in {dataDir}")
     print(f"Figures will be saved in {figDir}")
     print(f"Output will be saved in {outputDir}")
-
-    return files_root
 
 
 def download_data(

--- a/pycpt/src/pycpt/notebook.py
+++ b/pycpt/src/pycpt/notebook.py
@@ -133,7 +133,8 @@ def download_hindcasts(predictor_names, files_root, force_download, download_arg
 def download_forecasts(predictor_names, files_root, force_download, download_args):
     return [
         cached_download(
-            dl.forecasts[model], files_root, f'{model}_f',
+            dl.forecasts[model], files_root,
+            f'{model}_f{download_args["fdate"].year}',
             force_download, download_args
         )
         for model in predictor_names

--- a/pycpt/src/pycpt/notebook.py
+++ b/pycpt/src/pycpt/notebook.py
@@ -1209,7 +1209,9 @@ def plot_mme_flex_forecasts(
     )
 
 
-def construct_mme(fcsts, hcsts, Y, ensemble, predictor_names, cpt_args, domain_dir):
+# Like construct_mme but also returns hindcasts. This will be renamed
+# construct_mme in 3.0.
+def construct_mme_new(fcsts, hcsts, Y, ensemble, predictor_names, cpt_args, domain_dir):
     outputDir = domain_dir / "output"
     det_fcst = []
     det_hcst = []
@@ -1256,6 +1258,13 @@ def construct_mme(fcsts, hcsts, Y, ensemble, predictor_names, cpt_args, domain_d
     pr_hcst.to_netcdf(outputDir / ('MME_probabilistic_hindcasts.nc'))
     nextgen_skill.to_netcdf(outputDir / ('MME_skill_scores.nc'))
 
+    return det_hcst, pev_hcst, det_fcst, pr_fcst, pev_fcst, nextgen_skill
+
+
+# Backwards-compatible version of construct_mme_new, to avoid breaking existing
+# notebooks.
+def construct_mme(*args):
+    det_hcst, pev_hcst, det_fcst, pr_fcst, pev_fcst, nextgen_skill = construct_mme_new(*args)
     return det_fcst, pr_fcst, pev_fcst, nextgen_skill
 
 


### PR DESCRIPTION
This is needed urgently for a WFP Lesotho deliverable (automating forecast generation).

The most interesting change is that  you can now omit `lead_low` and `lead_high` from the configuration, and they will be inferred from `fdate` and `target`. In the interest of backwards compatibility, configurations that specify `lead_low` and `lead_high` are still allowed, but if the values are inconsistent with `fdate` and `target` then an error is now raised. While this is not strictly backwards-compatible, the only notebooks it will break (if any) are ones that have a serious error that had  previously gone unnoticed.

Another user-visible improvement is that the downloaded netcdf file for forecasts now has the year in it, so forecasts for different years don't get downloaded to the same file. This makes it safe to use `force_download=False` when generating forecasts for multiple years, which obviously saves a lot of downloading.