### PR TITLE
Support target_first_year/target_final_year in notebooks

### DIFF
--- a/pycpt/src/pycpt/automation.py
+++ b/pycpt/src/pycpt/automation.py
@@ -93,32 +93,20 @@ def update_all(dest_dir, issue_months, skip_issue_dates,
                now=None, persistent_dir=None):
     if now is None:
         now = datetime.datetime.now()
-    target_start, target_end = dl.parse_target(download_args['target'])
-    target_length = (target_end - target_start) % 12 + 1
-    target_mid = (target_start - 1 + target_length // 2) % 12 + 1
     for issue_month in issue_months:
-        modified_download_args = dict(download_args)
         month_dir = Path(dest_dir) / f'{issue_month:02}'
-        if 'target_first_year' in download_args and 'target_final_year' in download_args:
-            if 'first_year' in download_args or 'final_year' in download_args:
-                raise Exception('first_year/final_year are incompatible with target_first_year/target_final_year')
-            if issue_month > target_mid:
-                modified_download_args['first_year'] = download_args['target_first_year'] - 1
-                modified_download_args['final_year'] = download_args['target_final_year'] - 1
-            else:
-                modified_download_args['first_year'] = download_args['target_first_year']
-                modified_download_args['final_year'] = download_args['target_final_year']
-        elif 'first_year' in download_args and 'final_year' in download_args:
-            if 'target_first_year' in download_args or 'target_final_year' in download_args:
-                raise Exception('first_year/final_year are incompatible with target_first_year/target_final_year')
-            # Preserving the weird behavior of first_year and
-            # final_year from pycpt 2.7.2 for backwards
-            # compatibility. New configurations should use
-            # target_first_year and target_final_year instead.
-            if issue_month > target_start:
-                modified_download_args['first_year'] -= 1
-                modified_download_args['final_year'] -= 1
-        issue_date = datetime.datetime(modified_download_args['final_year'] + 1, issue_month, 1)
+
+        if 'final_year' in download_args:
+            assert 'target_final_year' not in download_args, \
+                "Don't mix first_year/final_year with target_first_year/target_final_year"
+            first_issue_year = download_args['final_year'] + 1
+        else:
+            assert 'target_final_year' in download_args, \
+                'Either final_year or target_final_year must be specified'
+            delta = notebook.issue_year_delta(issue_month, download_args['target'])
+            first_issue_year = download_args['target_final_year'] + 1 + delta
+
+        issue_date = datetime.datetime(first_issue_year, issue_month, 1)
         with tempfile.TemporaryDirectory() as tempdir:
             while issue_date < now:
                 fcst_file = month_dir / f'MME_deterministic_forecast_{issue_date.year}.nc'


### PR DESCRIPTION
When forecasting e.g. the MAM season with Dec, Jan, and Feb initializations, it's more convenient to name the training period by the years of the target seasons rather than the years of the initializations, so that the range of years is the same for the Dec initialization (which is in the previous calendar year relative to the season) as for the Jan and Feb initializations (which are in the same calendar year as the season).

For use in FbF operational procedure (the `generate-forecasts` script), we introduced `target_first_year` and  `target_final_year` as alternatives to `first_year` and `final_year`. We unintentionally did it in a way that made them only available in `generate-forecasts`, not in notebooks. This makes them available in notebooks as well. 