### PR TITLE
Don't use mutable defaults

### DIFF
--- a/cpt-core/src/cptcore/functional/cca.py
+++ b/cpt-core/src/cptcore/functional/cca.py
@@ -24,7 +24,7 @@ def canonical_correlation_analysis(
         skillmask_threshold=None,
         scree=False,
         synchronous_predictors=False,
-        cpt_kwargs={}, # a dict of kwargs that will be passed to CPT 
+        cpt_kwargs=None, # a dict of kwargs that will be passed to CPT
         x_lat_dim=None, 
         x_lon_dim=None, 
         x_sample_dim=None, 
@@ -37,8 +37,11 @@ def canonical_correlation_analysis(
         f_lon_dim=None, 
         f_sample_dim=None, 
         f_feature_dim=None, 
-        **kwargs
+        **_
     ):
+    if cpt_kwargs is None:
+        cpt_kwargs = {}
+
     assert validation.upper() in ['DOUBLE-CROSSVALIDATION', 'CROSSVALIDATION', 'RETROACTIVE'], "validation must be one of ['DOUBLE-CROSSVALIDATION', 'CROSSVALIDATION', 'RETROACTIVE']"
     assert isinstance(crossvalidation_window, int) and crossvalidation_window %2 == 1, "crossvalidation window must be odd integer"
     assert 0 < retroactive_initial_training_period < 100, 'retroactive_initial_training_period must be a percentage between 0 and 100'

--- a/cpt-core/src/cptcore/functional/deterministic_skill.py
+++ b/cpt-core/src/cptcore/functional/deterministic_skill.py
@@ -9,7 +9,7 @@ def deterministic_skill(
         X,  # Predictor Dataset in an Xarray DataArray with three dimensions, XYT 
         Y,  # Predictand Dataset in an Xarray DataArray with three dimensions, XYT 
         synchronous_predictors=False,
-        cpt_kwargs={}, # a dict of kwargs that will be passed to CPT 
+        cpt_kwargs=None, # a dict of kwargs that will be passed to CPT
         x_lat_dim=None, 
         x_lon_dim=None, 
         x_sample_dim=None, 
@@ -18,8 +18,11 @@ def deterministic_skill(
         y_lon_dim=None, 
         y_sample_dim=None, 
         y_feature_dim=None, 
-        **kwargs
+        **_ # ignore unsupported kwargs like transform_predictand. TODO I would rather we not pass them.
     ):
+    if cpt_kwargs is None:
+        cpt_kwargs = {}
+
     x_lat_dim, x_lon_dim, x_sample_dim,  x_feature_dim = guess_cptv10_coords(X, x_lat_dim, x_lon_dim, x_sample_dim,  x_feature_dim )
     is_valid_cptv10(X)
 

--- a/cpt-core/src/cptcore/functional/mlr.py
+++ b/cpt-core/src/cptcore/functional/mlr.py
@@ -13,7 +13,7 @@ def multiple_regression(
         crossvalidation_window=5,  # number of samples to leave out in each cross-validation step 
         transform_predictand=None,  # transformation to apply to the predictand dataset - None, 'Empirical', 'Gamma'
         tailoring=None,  # tailoring None, Anomaly, StdAnomaly, or SPI (SPI only available on Gamma)
-        cpt_kwargs={}, # a dict of kwargs that will be passed to CPT 
+        cpt_kwargs=None, # a dict of kwargs that will be passed to CPT
         retroactive_initial_training_period=45, # percent of samples to be used as initial training period for retroactive validation
         retroactive_step=10, # percent of samples to increment retroactive training period by each time. 
         validation='crossvalidation', #type of leave-n-out crossvalidation to use
@@ -37,6 +37,9 @@ def multiple_regression(
         f_feature_dim=None, 
         **kwargs
     ):
+    if cpt_kwargs is None:
+        cpt_kwargs = {}
+
     assert validation.upper() in ['DOUBLE-CROSSVALIDATION','CROSSVALIDATION', 'RETROACTIVE'], "validation must be one of ['CROSSVALIDATION','DOUBLE-CROSSVALIDATION', 'RETROACTIVE']"
     assert isinstance(crossvalidation_window, int) and crossvalidation_window %2 == 1, "crossvalidation window must be odd integer"
     assert 0 < retroactive_initial_training_period < 100, 'retroactive_initial_training_period must be a percentage between 0 and 100'

--- a/cpt-core/src/cptcore/functional/pcr.py
+++ b/cpt-core/src/cptcore/functional/pcr.py
@@ -14,7 +14,7 @@ def principal_components_regression(
         transform_predictand=None,  # transformation to apply to the predictand dataset - None, 'Empirical', 'Gamma'
         tailoring=None,  # tailoring None, Anomaly, StdAnomaly, or SPI (SPI only available on Gamma)
         x_eof_modes=(1,5), # minimum and maximum of allowed X Principal Componenets 
-        cpt_kwargs={}, # a dict of kwargs that will be passed to CPT 
+        cpt_kwargs=None, # a dict of kwargs that will be passed to CPT
         retroactive_initial_training_period=45, # percent of samples to be used as initial training period for retroactive validation
         retroactive_step=10, # percent of samples to increment retroactive training period by each time. 
         validation='CROSSVALIDATION', #type of leave-n-out crossvalidation to use
@@ -36,6 +36,9 @@ def principal_components_regression(
         f_feature_dim=None, 
         **kwargs
     ):
+    if cpt_kwargs is None:
+        cpt_kwargs = {}
+
     assert validation.upper() in ['DOUBLE-CROSSVALIDATION', 'CROSSVALIDATION', 'RETROACTIVE'], "validation must be one of ['CROSSVALIDATION', 'DOUBLE-CROSSVALIDATION', 'RETROACTIVE']"
     assert isinstance(crossvalidation_window, int) and crossvalidation_window %2 == 1, "crossvalidation window must be odd integer"
     assert 0 < retroactive_initial_training_period < 100, 'retroactive_initial_training_period must be a percentage between 0 and 100'

--- a/cpt-core/src/cptcore/functional/probabilistic_forecast_verification.py
+++ b/cpt-core/src/cptcore/functional/probabilistic_forecast_verification.py
@@ -10,7 +10,7 @@ def probabilistic_forecast_verification(
         X,  # Predictor Dataset in an Xarray DataArray with three dimensions, XYT 
         Y,  # Predictand Dataset in an Xarray DataArray with three dimensions, XYT 
         synchronous_predictors=False,
-        cpt_kwargs={}, # a dict of kwargs that will be passed to CPT 
+        cpt_kwargs=None, # a dict of kwargs that will be passed to CPT
         x_lat_dim=None, 
         x_lon_dim=None, 
         x_sample_dim=None, 
@@ -21,6 +21,8 @@ def probabilistic_forecast_verification(
         y_feature_dim=None, 
         **kwargs
     ):
+    if cpt_kwargs is None:
+        cpt_kwargs = {}
     x_lat_dim, x_lon_dim, x_sample_dim,  x_feature_dim = guess_cptv10_coords(X, x_lat_dim, x_lon_dim, x_sample_dim,  x_feature_dim )
     is_valid_cptv10(X)
 

--- a/pycpt/src/pycpt/notebook.py
+++ b/pycpt/src/pycpt/notebook.py
@@ -257,12 +257,12 @@ def evaluate_models(
     #         this is using X in place of F, with the year coordinates changed to n+100 years
     #         because CPT does not allow you to make forecasts for in-sample data
             cca_h, cca_f, cca_s, cca_px, cca_py = cc.canonical_correlation_analysis(model_hcst, Y, \
-            F=ce.redate(model_hcst, yeardelta=48), **cpt_args)
+            F=ce.redate(model_hcst, yeardelta=48), **cpt_args, cpt_kwargs= cpt_kwargs)
             cca_h = xr.merge([cca_h, ce.redate(cca_f.probabilistic, yeardelta=-48), ce.redate(cca_f.prediction_error_variance, yeardelta=-48)])
 
     #         # use the in-sample probabilistic hindcasts to perform probabilistic forecast verification
     #         # warning - this produces unrealistically optimistic values
-            cca_pfv = cc.probabilistic_forecast_verification(cca_h.probabilistic, Y, **cpt_args)
+            cca_pfv = cc.probabilistic_forecast_verification(cca_h.probabilistic, Y, **cpt_args, cpt_kwargs=cpt_kwargs)
             cca_s = xr.merge([cca_s, cca_pfv])
 
             hcsts.append(cca_h)
@@ -274,17 +274,17 @@ def evaluate_models(
         elif str(MOS).upper() == 'PCR':
 
             # fit PCR model between X & Y and produce real-time forecasts for F
-            pcr_h, pcr_rtf, pcr_s, pcr_px = cc.principal_components_regression(model_hcst, Y, F=forecast_data[i], **cpt_args)
+            pcr_h, pcr_rtf, pcr_s, pcr_px = cc.principal_components_regression(model_hcst, Y, F=forecast_data[i], **cpt_args, cpt_kwargs=cpt_kwargs)
 
             # fit PCR model again between X & Y, and produce in-sample probabilistic hindcasts
             # this is using X in place of F, with the year coordinates changed to n+100 years
             # because CPT does not allow you to make forecasts for in-sample data
-            pcr_h, pcr_f, pcr_s, pcr_px = cc.principal_components_regression(model_hcst, Y, F=ce.redate(model_hcst, yeardelta=48), **cpt_args)
+            pcr_h, pcr_f, pcr_s, pcr_px = cc.principal_components_regression(model_hcst, Y, F=ce.redate(model_hcst, yeardelta=48), **cpt_args, cpt_kwargs=cpt_kwargs)
             pcr_h = xr.merge([pcr_h, ce.redate(pcr_f.probabilistic, yeardelta=-48), ce.redate(pcr_f.prediction_error_variance, yeardelta=-48)])
 
             # use the in-sample probabilistic hindcasts to perform probabilistic forecast verification
             # warning - this produces unrealistically optimistic values
-            pcr_pfv = cc.probabilistic_forecast_verification(pcr_h.probabilistic, Y, **cpt_args)
+            pcr_pfv = cc.probabilistic_forecast_verification(pcr_h.probabilistic, Y, **cpt_args, cpt_kwargs=cpt_kwargs)
             pcr_s = xr.merge([pcr_s, pcr_pfv])
             hcsts.append(pcr_h)
             fcsts.append(pcr_rtf)
@@ -293,7 +293,7 @@ def evaluate_models(
             pys.append(pcr_px)	# dummy assignment since there are no Y PCs in PCR
         else:
             # simply compute deterministic skill scores of non-corrected ensemble means
-            nomos_skill = cc.deterministic_skill(model_hcst, Y, **cpt_args)
+            nomos_skill = cc.deterministic_skill(model_hcst, Y, **cpt_args, cpt_kwargs=cpt_kwargs)
             skill.append(nomos_skill.where(nomos_skill > -999, other=np.nan))
 
         # choose what data to export here (any of the above results data arrays can be saved to netcdf)


### PR DESCRIPTION
It's dangerous to use `{}` as a default argument in a python function. See https://docs.python-guide.org/writing/gotchas/ .

Also passing cpt_kwargs to more functions. This helps with debugging because it allows us to enable the "interactive" option, which previously only worked with CCA.