### PR TITLE
Save individual model forecasts to separate files

### DIFF
--- a/pycpt/src/pycpt/notebook.py
+++ b/pycpt/src/pycpt/notebook.py
@@ -914,9 +914,9 @@ def plot_forecasts(
         figName = (
             MOS
             + ForTitle.replace(" ", "_")
-            + "["
-            + ",".join(predictor_names)
-            + "]"
+            + "_"
+            + predictor_names[i]
+            + "_"
             + "[determinstic-probabilistic]-Forecast"
             + ".png"
         )


### PR DESCRIPTION
Resolves Sylwia's complaint from Malawi that the png file is named as if it contained all the models' forecasts but actually contains only one. I had trouble getting all the forecasts into a single file, so instead I'm just generating one png file per model.