### PR TITLE
Fix bug in generate-forecasts-from-config

### DIFF
--- a/pycpt/src/pycpt/automation.py
+++ b/pycpt/src/pycpt/automation.py
@@ -116,7 +116,7 @@ def update_all(dest_dir, issue_months, skip_issue_dates,
                     print(f'skipping issue date {issue_date}')
                 else:
                     print(f"generate forecast initialized {issue_date}")
-                    issue_download_args = dict(modified_download_args, fdate=issue_date)
+                    issue_download_args = dict(download_args, fdate=issue_date)
                     pycpt_dir = Path(persistent_dir or tempdir)
                     try:
                         update_one_issue(


### PR DESCRIPTION
In 616a53d0d66281c850db5340fd3d6e933c57a63f I made a change that was only intended to affect the notebook, but accidentally broke generate-forecasts-from-config.