### PR TITLE
Unbreak plot_forecasts and plot_skill

### DIFF
--- a/pycpt/src/pycpt/automation.py
+++ b/pycpt/src/pycpt/automation.py
@@ -1,10 +1,11 @@
 import cptdl as dl
 import datetime
+import matplotlib.pyplot as plt
+import numpy as np
 from pathlib import Path
+import requests.exceptions
 import shutil
 import tempfile
-import numpy as np
-import requests.exceptions
 import xarray as xr
 
 from . import notebook
@@ -78,6 +79,7 @@ def update_one_issue(
         domain_dir,
         det_fcst,
     )
+    plt.close('all')
     figfile = domain_dir / 'figures' / f"{MOS}_ensemble_probabilistic-deterministicForecast.png"
     figname = f"forecast_{download_args['target']}_ini-{issue_year}-{issue_month:02}.png"
     # Using shutil.move rather than figfile.rename because the latter

--- a/pycpt/src/pycpt/notebook.py
+++ b/pycpt/src/pycpt/notebook.py
@@ -401,7 +401,6 @@ def plot_skill(predictor_names, skill, MOS, files_root, skill_metrics, domain=No
         files_root / "figures" / figName,
         bbox_inches="tight",
     )
-    plt.close()
 
 
 def plot_cca_modes(
@@ -547,7 +546,6 @@ def plot_cca_modes(
                 # save plots
                 figName = MOS + "_" + str(model) + "_CCA_mode_" + str(mode + 1) + ".png"
                 fig.savefig(files_root / "figures" / figName, bbox_inches="tight")
-                plt.close()
     else:
         print("You will need to set MOS=CCA in order to see CCA Modes")
 
@@ -710,7 +708,6 @@ def plot_eof_modes(
                 # save plots
                 figName = MOS + "_" + str(model) + "_EOF_mode_" + str(mode + 1) + ".png"
                 fig.savefig(files_root / "figures" / figName, bbox_inches="tight")
-                plt.close()
     elif MOS == "PCR":
         for i, model in enumerate(predictor_names):
             for mode in range(nmodes):
@@ -758,7 +755,6 @@ def plot_eof_modes(
                 # save plots
                 figName = MOS + "_" + str(model) + "_EOF_mode_" + str(mode + 1) + ".png"
                 fig.savefig(files_root / "figures" / figName, bbox_inches="tight")
-                plt.close()
     else:
         print("You will need to set MOS=CCA in order to see CCA Modes")
 
@@ -818,7 +814,6 @@ def plot_forecasts(
             files_root / "figures" / "Test.png",
             bbox_inches="tight",
         )  # ,pad_inches = 0)
-        plt.close()
 
         matplotlibInstance.clf()
         cartopyInstance.cla()
@@ -901,7 +896,6 @@ def plot_forecasts(
             bbox_inches="tight",
             pad_inches=0,
         )
-        plt.close()
 
         ax2 = fig.add_subplot(2, 2, 2)
         ax2.set_axis_off()


### PR DESCRIPTION
In https://github.com/iri-pycpt/pycpt/pull/98 I resolved a warning in generate-forecasts-from-config by closing figures so they don't accumulate in memory. I didn't notice it at the time, but this caused plot_forecasts and plot_skill to stop displaying anything in the notebook.

This was released in pycpt 2.9.4, but almost nobody is using that version, which explains why it hadn't been reported.